### PR TITLE
Flag `--output`, `-o`

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,6 +60,14 @@
       "args": ["get", "project", "pippo", "--cluster-name", "local"]
     },
     {
+      "name": "Command: Get Project, -o yaml",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "main.go",
+      "args": ["get", "project", "pippo", "--cluster-name", "local", "-o", "yaml"]
+    },
+    {
       "name": "Generate error",
       "type": "go",
       "request": "launch",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,6 +60,14 @@
       "args": ["get", "project", "pippo", "--cluster-name", "local"]
     },
     {
+      "name": "Command: Get Project, -o json",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "main.go",
+      "args": ["get", "project", "pippo", "--cluster-name", "local", "-o", "json"]
+    },
+    {
       "name": "Command: Get Project, -o yaml",
       "type": "go",
       "request": "launch",

--- a/e2e/rancher/project_test.go
+++ b/e2e/rancher/project_test.go
@@ -21,7 +21,7 @@ var _ = Describe("Project", Ordered, func() {
 	})
 
 	Context("ListProjects", func() {
-		It("should get default projects list", FlakeAttempts(5), func() {
+		It("should get default projects list", func() {
 			out, _, err := rancherx.Run("get", "project", "--cluster-name", "local")
 			Expect(err).To(BeNil())
 
@@ -30,6 +30,13 @@ var _ = Describe("Project", Ordered, func() {
 			Expect(len(outTable)).To(Equal(2))
 			Expect(outTable[0][1]).To(Equal("Default"))
 			Expect(outTable[1][1]).To(Equal("System"))
+		})
+
+		It("should not find projects in cluster pluto", func() {
+			out, _, err := rancherx.Run("get", "project", "--cluster-name", "pluto")
+			Expect(err).To(BeNil())
+
+			Expect(out).To(Equal("No projects found in \"pluto\" cluster.\n"))
 		})
 	})
 
@@ -93,6 +100,21 @@ var _ = Describe("Project", Ordered, func() {
 			Expect(project.Spec.DisplayName).To(Equal("pippo2"))
 			Expect(project.Spec.Description).To(Equal("bar1"))
 		})
+
+		It("should not find 'pippo3'", func() {
+			out, _, err := rancherx.Run("get", "project", "pippo3", "--cluster-name", "local")
+			Expect(err).To(BeNil())
+
+			Expect(out).To(Equal("Project \"pippo3\" not found.\n"))
+		})
+
+		It("should find 'pippo2' and not find 'pippo3'", func() {
+			out, _, err := rancherx.Run("get", "project", "pippo3", "pippo2", "--cluster-name", "local")
+			Expect(err).To(BeNil())
+
+			Expect(out).To(ContainSubstring("Project \"pippo3\" not found.\n"))
+			Expect(out).To(ContainSubstring("pippo2"))
+		})
 	})
 
 	Context("DeleteProject", Ordered, func() {
@@ -107,7 +129,7 @@ var _ = Describe("Project", Ordered, func() {
 			out, _, err := rancherx.Run("get", "project", "pippo", "--cluster-name", "local")
 			Expect(err).To(BeNil())
 
-			Expect(out).To(Equal(""))
+			Expect(out).To(Equal("Project \"pippo\" not found.\n"))
 		})
 	})
 

--- a/pkg/cli/get.go
+++ b/pkg/cli/get.go
@@ -84,7 +84,7 @@ func newGetProjectsCmd(client *rest.RESTClient) *cobra.Command {
 	}
 
 	cmd.Flags().StringVar(&cfg.ClusterName, "cluster-name", "", "ClusterName is the name of the cluster the project belongs to. Immutable.")
-	cmd.Flags().StringVarP(&cfg.Common.Output, "output", "o", "", "Output format.")
+	cmd.Flags().StringVarP(&cfg.Common.Output, "output", "o", "", "Output format. One of: (json, yaml)")
 
 	cmd.MarkFlagRequired("cluster-name")
 	cmd.RegisterFlagCompletionFunc("cluster-name", ClustersFlagValidator(client))

--- a/pkg/cli/get.go
+++ b/pkg/cli/get.go
@@ -43,10 +43,6 @@ func newGetProjectsCmd(client *rest.RESTClient) *cobra.Command {
 				return fmt.Errorf("getting projects: %w", err)
 			}
 
-			if len(projects.Items) == 0 {
-				fmt.Printf("No resources found in %q cluster.\n", cfg.ClusterName)
-			}
-
 			items := []v3.Project{}
 
 			if len(args) > 0 {
@@ -58,6 +54,8 @@ func newGetProjectsCmd(client *rest.RESTClient) *cobra.Command {
 				for _, arg := range args {
 					if projectMap[arg].Name != "" { // is not empty project
 						items = append(items, projectMap[arg])
+					} else {
+						fmt.Printf("Project %q not found.\n", arg)
 					}
 				}
 			} else {
@@ -66,6 +64,11 @@ func newGetProjectsCmd(client *rest.RESTClient) *cobra.Command {
 				})
 
 				items = append(items, projects.Items...)
+
+				if len(items) == 0 {
+					fmt.Printf("No projects found in %q cluster.\n", cfg.ClusterName)
+					return nil
+				}
 			}
 
 			rancher.PrintProject(

--- a/pkg/cli/get.go
+++ b/pkg/cli/get.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/client-go/rest"
 
-	"github.com/torchiaf/kubectl-rancherx/pkg/output"
 	rancher "github.com/torchiaf/kubectl-rancherx/pkg/rancher"
 )
 
@@ -69,10 +68,10 @@ func newGetProjectsCmd(client *rest.RESTClient) *cobra.Command {
 				items = append(items, projects.Items...)
 			}
 
-			output.Print(
+			rancher.PrintProject(
 				c.Context(),
 				items,
-				cfg.Common.Output,
+				cfg,
 				func(item v3.Project) string {
 					return fmt.Sprintf("%s\t%s", item.Name, item.Spec.DisplayName)
 				},

--- a/pkg/flag/models.go
+++ b/pkg/flag/models.go
@@ -1,5 +1,6 @@
 package flag
 
 type CommonConfig struct {
-	Set []string
+	Output string // json, yaml
+	Set    []string
 }

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -8,26 +8,24 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func Print[T any](ctx context.Context, items []T, formatter string, def func(item T) string) error {
-	for _, item := range items {
-		switch formatter {
-		case "yaml":
-			yamlData, err := yaml.Marshal(item)
-			if err != nil {
-				return err
-			}
-
-			fmt.Println(string(yamlData))
-		case "json":
-			jsonData, err := json.MarshalIndent(item, "", "  ")
-			if err != nil {
-				return err
-			}
-
-			fmt.Println(string(jsonData))
-		default:
-			fmt.Println(def(item))
+func Print[T any](ctx context.Context, item T, formatter string, def func(item T) string) error {
+	switch formatter {
+	case "yaml":
+		yamlData, err := yaml.Marshal(item)
+		if err != nil {
+			return err
 		}
+
+		fmt.Println(string(yamlData))
+	case "json":
+		jsonData, err := json.MarshalIndent(item, "", "  ")
+		if err != nil {
+			return err
+		}
+
+		fmt.Println(string(jsonData))
+	default:
+		fmt.Println(def(item))
 	}
 
 	return nil

--- a/pkg/output/output.go
+++ b/pkg/output/output.go
@@ -1,0 +1,34 @@
+package output
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+)
+
+func Print[T any](ctx context.Context, items []T, formatter string, def func(item T) string) error {
+	for _, item := range items {
+		switch formatter {
+		case "yaml":
+			yamlData, err := yaml.Marshal(item)
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(yamlData))
+		case "json":
+			jsonData, err := json.MarshalIndent(item, "", "  ")
+			if err != nil {
+				return err
+			}
+
+			fmt.Println(string(jsonData))
+		default:
+			fmt.Println(def(item))
+		}
+	}
+
+	return nil
+}

--- a/pkg/rancher/project.go
+++ b/pkg/rancher/project.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	apiv3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
+	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/torchiaf/kubectl-rancherx/pkg/flag"
 	"github.com/torchiaf/kubectl-rancherx/pkg/manager"
+	"github.com/torchiaf/kubectl-rancherx/pkg/output"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/rest"
 )
@@ -19,13 +20,13 @@ var Resources = []string{
 	"project", "projects",
 }
 
-func GetProject(ctx context.Context, client *rest.RESTClient, name string, clusterName string) (*apiv3.Project, error) {
+func GetProject(ctx context.Context, client *rest.RESTClient, name string, clusterName string) (*v3.Project, error) {
 
-	projects := &apiv3.ProjectList{}
+	projects := &v3.ProjectList{}
 
 	err := manager.List(ctx, client, project, clusterName, projects)
 	if err != nil {
-		return &apiv3.Project{}, err
+		return &v3.Project{}, err
 	}
 
 	for _, project := range projects.Items {
@@ -34,16 +35,16 @@ func GetProject(ctx context.Context, client *rest.RESTClient, name string, clust
 		}
 	}
 
-	return &apiv3.Project{}, fmt.Errorf("project %q not found in cluster %q", name, clusterName)
+	return &v3.Project{}, fmt.Errorf("project %q not found in cluster %q", name, clusterName)
 }
 
-func ListProjects(ctx context.Context, client *rest.RESTClient, clusterName string) (*apiv3.ProjectList, error) {
+func ListProjects(ctx context.Context, client *rest.RESTClient, clusterName string) (*v3.ProjectList, error) {
 
-	projects := &apiv3.ProjectList{}
+	projects := &v3.ProjectList{}
 
 	err := manager.List(ctx, client, project, clusterName, projects)
 	if err != nil {
-		return &apiv3.ProjectList{}, err
+		return &v3.ProjectList{}, err
 	}
 
 	return projects, nil
@@ -51,7 +52,7 @@ func ListProjects(ctx context.Context, client *rest.RESTClient, clusterName stri
 
 func CreateProject(ctx context.Context, client *rest.RESTClient, name string, cfg *ProjectConfig) error {
 
-	projects := &apiv3.ProjectList{}
+	projects := &v3.ProjectList{}
 
 	err := manager.List(ctx, client, project, cfg.ClusterName, projects)
 	if err != nil {
@@ -64,14 +65,14 @@ func CreateProject(ctx context.Context, client *rest.RESTClient, name string, cf
 		}
 	}
 
-	obj := &apiv3.Project{
+	obj := &v3.Project{
 		// ObjectMeta: v1.ObjectMeta{
 		// 	Name: name,
 		// },
 		ObjectMeta: v1.ObjectMeta{
 			GenerateName: "p-",
 		},
-		Spec: apiv3.ProjectSpec{
+		Spec: v3.ProjectSpec{
 			ClusterName: cfg.ClusterName,
 			DisplayName: cfg.DisplayName,
 		},
@@ -87,7 +88,7 @@ func CreateProject(ctx context.Context, client *rest.RESTClient, name string, cf
 
 func DeleteProject(ctx context.Context, client *rest.RESTClient, name string, clusterName string) error {
 
-	projects := &apiv3.ProjectList{}
+	projects := &v3.ProjectList{}
 
 	err := manager.List(ctx, client, project, clusterName, projects)
 	if err != nil {
@@ -108,4 +109,13 @@ func DeleteProject(ctx context.Context, client *rest.RESTClient, name string, cl
 	}
 
 	return manager.Delete(ctx, client, project, clusterName, projectName)
+}
+
+func PrintProject(ctx context.Context, items []v3.Project, cfg *ProjectConfig, def func(item v3.Project) string) error {
+	for _, item := range items {
+		item.ObjectMeta.ManagedFields = nil
+		return output.Print(ctx, item, cfg.Common.Output, def)
+	}
+
+	return nil
 }

--- a/pkg/rancher/project.go
+++ b/pkg/rancher/project.go
@@ -114,7 +114,11 @@ func DeleteProject(ctx context.Context, client *rest.RESTClient, name string, cl
 func PrintProject(ctx context.Context, items []v3.Project, cfg *ProjectConfig, def func(item v3.Project) string) error {
 	for _, item := range items {
 		item.ObjectMeta.ManagedFields = nil
-		return output.Print(ctx, item, cfg.Common.Output, def)
+
+		err := output.Print(ctx, item, cfg.Common.Output, def)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil


### PR DESCRIPTION
### Summary

- Adding a generic `output` flag to print objects in `json` and `yaml` format

```
kubectl-rancherx get project --cluster-name local pippo -o json
```

- Applying the flag to get/list projects commands
- Adding e2e tests

### TODO

rebase after merge https://github.com/torchiaf/kubectl-rancherx/pull/4